### PR TITLE
Incidence inconsistence def

### DIFF
--- a/coupled_learning/circuit_utils.py
+++ b/coupled_learning/circuit_utils.py
@@ -80,7 +80,7 @@ class Circuit(object):
 
     def _jax_hessian(self):
         ''' Compute the Hessian of the network with respect to the conductances. '''
-        return jnp.dot(self.incidence_matrix*self.conductances,jnp.transpose(self.incidence_matrix))
+        return jnp.dot(self.incidence_matrix.todense()*self.conductances,jnp.transpose(self.incidence_matrix.todense()))
     
     def constraint_matrix(self, indices_nodes, restrictionType = 'node'):
         ''' Compute the constraint matrix Q for the circuit and the nodes represented by indices_nodes. 
@@ -204,6 +204,8 @@ class Circuit(object):
             Extended Hessian. H is a dense matrix of size (n + len(indices_nodes)) x (n + len(indices_nodes)).
         
         '''
+        Q = Q.todense()
+
         extendedHessian = jnp.block([[self._jax_hessian(), Q],[jnp.transpose(Q), jnp.zeros(shape=(jnp.shape(Q)[1],jnp.shape(Q)[1]))]])
         # bmat([[self._hessian(), Q], [Q.T, None]], format='csr', dtype=float)
         return extendedHessian
@@ -361,6 +363,8 @@ class Circuit(object):
         # determine the index of the edge in the list of edges
         index_edge = list(self.graph.edges).index(tuple(edge))
         self.graph.remove_edge(*edge)
+        self.graph.remove_nodes_from(list(nx.isolates(self.graph)))
+
         self.n = self.graph.number_of_nodes()
         self.ne = self.graph.number_of_edges()
         self.pts = np.array([self.graph.nodes[node]['pos'] for node in self.graph.nodes])

--- a/coupled_learning/circuit_utils.py
+++ b/coupled_learning/circuit_utils.py
@@ -87,7 +87,7 @@ class Circuit(object):
 
     def _jax_hessian(self):
         ''' Compute the Hessian of the network with respect to the conductances. '''
-        return jnp.dot(self.incidence_matrix.todense()*self.conductances,jnp.transpose(self.incidence_matrix.todense()))
+        return jnp.dot(self.incidence_matrix*self.conductances,jnp.transpose(self.incidence_matrix))
     
     @staticmethod
     def _shessian(conductances,incidence_matrix):
@@ -216,8 +216,6 @@ class Circuit(object):
             Extended Hessian. H is a dense matrix of size (n + len(indices_nodes)) x (n + len(indices_nodes)).
         
         '''
-        Q = Q.todense()
-
         extendedHessian = jnp.block([[self._jax_hessian(), Q],[jnp.transpose(Q), jnp.zeros(shape=(jnp.shape(Q)[1],jnp.shape(Q)[1]))]])
         # bmat([[self._hessian(), Q], [Q.T, None]], format='csr', dtype=float)
         return extendedHessian
@@ -418,8 +416,6 @@ class Circuit(object):
         # determine the index of the edge in the list of edges
         index_edge = list(self.graph.edges).index(tuple(edge))
         self.graph.remove_edge(*edge)
-        self.graph.remove_nodes_from(list(nx.isolates(self.graph)))
-
         self.n = self.graph.number_of_nodes()
         self.ne = self.graph.number_of_edges()
         self.pts = np.array([self.graph.nodes[node]['pos'] for node in self.graph.nodes])

--- a/coupled_learning/cl_utils.py
+++ b/coupled_learning/cl_utils.py
@@ -801,7 +801,7 @@ class CL(Circuit):
         #     f.write('\t"pts": {},\n'.format(self.pts.tolist()))
         #     f.write('\t"edges": {}\n'.format(list(self.graph.edges)))
         #     f.write('}')
-
+        
         with open(path, 'w') as f:
             json.dump({
                 "nodes":list(self.graph.nodes),

--- a/coupled_learning/localization_utils.py
+++ b/coupled_learning/localization_utils.py
@@ -124,14 +124,14 @@ def get_partition(basis):
     """
     return np.argmax(np.abs(basis), axis=1)
 
-def get_boundary(incidence_matrix, partition):
+def get_boundary(transpose_incidence_matrix, partition):
     """
     Compute the boundary of the network given the partition.
     The boundary corresponds to a boolean array of edges.
     The boundary is computed by finding the edges that connect nodes belonging to different regions in the partition.
-    Notice that incidence_matrix is the matrix of (edges, nodes). (it may be the transpose of the network incidence matrix)
+    transpose_incidence_matrix is the matrix of (edges, nodes), the transpose of each Circuit instance's incidence matrix.
     """
-    return np.abs(incidence_matrix.T.dot(partition)) > 0 
+    return np.abs(transpose_incidence_matrix.dot(partition)) > 0 
 
 def mask_overlap(edge_state, partition_boundary):
     """

--- a/coupled_learning/localization_utils.py
+++ b/coupled_learning/localization_utils.py
@@ -131,7 +131,7 @@ def get_boundary(incidence_matrix, partition):
     The boundary is computed by finding the edges that connect nodes belonging to different regions in the partition.
     Notice that incidence_matrix is the matrix of (edges, nodes). (it may be the transpose of the network incidence matrix)
     """
-    return np.abs(incidence_matrix.dot(partition)) > 0 
+    return np.abs(incidence_matrix.T.dot(partition)) > 0 
 
 def mask_overlap(edge_state, partition_boundary):
     """


### PR DESCRIPTION
The definition of incidence_matrix in localization_utils.py is inconsistent with that of the CL class, where it's its inverse.

In CL, incidence matrix (Number of Nodes, Number of Edges) while for localization_utils.py, it's dotted onto partition (NN) to produce an array (NE) so that would require it to be (NE, NN).