### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,14 +6,14 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os:
+  os: "ubuntu-22.04"
   tools:
     python: "3.9"
     # You can also specify other tool versions:
     # nodejs: "20"
     # rust: "1.70"
     # golang: "1.20"
-
+    
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
The read the docs build is failing because of the configuration -- "Invalid configuration option "build.os": expected one of (ubuntu-20.04, ubuntu-22.04), got None"

I have implemented read the docs on a personal mock GitHub project, and this seems to be the fix.